### PR TITLE
Require `future` version to be 0.14.0 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## x.y.z (unreleased)
+- CommonMark now requires `future >= 0.14.0` for uniform `builtins` imports in Python 2/3
+
 ## 0.9.0 (2019-05-02)
 - The CommonMark spec has been updated to 0.29. Completed by @iamahuman.
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     },
     cmdclass={'test': Test},
     install_requires=[
-        'future',
+        'future>=0.14.0',
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require},


### PR DESCRIPTION
I got the following import error and have been investigating for the reasons:
```
Traceback (most recent call last):
  ...
  File "/home/paul/relaunch/native/eggs/commonmark-0.9.0-py2.7.egg/commonmark/normalize_reference.py", line 16, in <module>
    from builtins import str, chr
ImportError: No module named builtins
```
It turns out, that with `future` package below version 0.14.0 one has to import via `from future.builtins import str, chr` whereas newer versions support builtins directly. See also the [changelog of future](https://github.com/PythonCharmers/python-future/blob/master/docs/changelog.rst#changes-in-version-0140-2014-10-02).

With this PR it is now ensured, we have at least version 0.14.0 or better.