### PR TITLE
setup.py: Only require future on Python 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## x.y.z (unreleased)
-- CommonMark now requires `future >= 0.14.0` for uniform `builtins` imports in Python 2/3
+- CommonMark now requires `future >= 0.14.0` on Python 2, for uniform `builtins` imports in Python 2/3
 
 ## 0.9.0 (2019-05-02)
 - The CommonMark spec has been updated to 0.29. Completed by @iamahuman.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     },
     cmdclass={'test': Test},
     install_requires=[
-        'future>=0.14.0',
+        'future>=0.14.0;python_version<"3"',
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require},


### PR DESCRIPTION
We only use future for the `builtins` module which is standard in Python 3.