### PR TITLE
Support rendering multi-line list items to rst

### DIFF
--- a/commonmark/render/rst.py
+++ b/commonmark/render/rst.py
@@ -119,11 +119,13 @@ class ReStructuredTextRenderer(Renderer):
             self.cr()
 
     def item(self, node, entering):
-        tagname = '*' if node.list_data['type'] == 'bullet' else '#.'
+        tagname = '* ' if node.list_data['type'] == 'bullet' else '#. '
 
         if entering:
-            self.out(tagname + ' ')
+            self.out(tagname)
+            self.indent_length += len(tagname)
         else:
+            self.indent_length -= len(tagname)
             self.cr()
 
     def block_quote(self, node, entering):

--- a/commonmark/tests/rst_tests.py
+++ b/commonmark/tests/rst_tests.py
@@ -100,6 +100,24 @@ This is a ordered list:
 """
         self.assertEqualRender(src_markdown, expected_rst)
 
+    def test_ordered_list_with_multi_line_items(self):
+        src_markdown = """
+This is an ordered list with multi-line items:
+1. First item,
+with lazy indentation.
+2. Second item,
+   with normal indentation.
+"""
+        expected_rst = """
+This is an ordered list with multi-line items:
+
+#. First item,
+   with lazy indentation.
+#. Second item,
+   with normal indentation.
+"""
+        self.assertEqualRender(src_markdown, expected_rst)
+
     def test_block_quote(self):
         src_markdown = """
 Before the blockquote:


### PR DESCRIPTION
For list items going across multiple lines, the renderer previously did
not indent the latter lines, which leads to invalid rst (see
https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#bullet-lists;
subsequent list items must line up with the first item).

This commit fixes that by introducing an indent when entering a list
item.

Note that there are still some issues (for example, paragraphs within
list items are still not handled correctly), but this at least seems to
be a step in the right direction.